### PR TITLE
Create devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "Python 3.11",
+  "image": "python:3.11",
+  "extensions": [
+    "github.copilot",
+    "copilot-chat-extension-id"
+  ]
+}


### PR DESCRIPTION
This pull request introduces a new development container configuration for Python 3.11. The `.devcontainer/devcontainer.json` file has been added, which specifies the use of the `python:3.11` image and includes extensions for GitHub Copilot and a chat extension. 